### PR TITLE
Fix and update environment script

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
 
-SL_PYTHON27=/opt/rh/python27/enable
-if [ -f "$SL_PYTHON27" ]; then
-   source $SL_PYTHON27
-fi
-
-source /home/software/root/bin/thisroot.sh
-source /home/software/geant4.10.00.p04/bin/geant4.sh
-
-# export RAT_SCONS=/home/software/scons-3.1.2
-
-# export TF_DIR=/usr/local
-# export CPPFLOW_DIR=/home/software/cppflow
-# export LIBRARY_PATH=$LIBRARY_PATH:$TF_DIR/lib
-# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TF_DIR/lib
-# export LIBRARY_PATH=$LIBRARY_PATH:$CPPFLOW_DIR/lib
-# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CPPFLOW_DIR/lib
-
-RAT_ENV=/rat/env.sh
-if [ -f "$RAT_ENV" ]; then
-    source $RAT_ENV
-else
-    printf "\nCould not find /rat/env.sh\nIf youre building RAT, please ignore.\nOtherwise, ensure RAT is mounted to /rat\n"
-fi
+source /home/scripts/setup-env.sh
 
 /bin/bash "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-source /opt/rh/python27/enable
+SL_PYTHON27=/opt/rh/python27/enable
+if [ -f "$SL_PYTHON27" ]; then
+   source $SL_PYTHON27
+fi
+
 source /home/software/root/bin/thisroot.sh
 source /home/software/geant4.10.00.p04/bin/geant4.sh
 
 # export RAT_SCONS=/home/software/scons-3.1.2
+
 # export TF_DIR=/usr/local
 # export CPPFLOW_DIR=/home/software/cppflow
 # export LIBRARY_PATH=$LIBRARY_PATH:$TF_DIR/lib
@@ -12,8 +17,9 @@ source /home/software/geant4.10.00.p04/bin/geant4.sh
 # export LIBRARY_PATH=$LIBRARY_PATH:$CPPFLOW_DIR/lib
 # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CPPFLOW_DIR/lib
 
-if [ -f /rat/env.sh ]; then
-    source /rat/env.sh
+RAT_ENV=/rat/env.sh
+if [ -f "$RAT_ENV" ]; then
+    source $RAT_ENV
 else
     printf "\nCould not find /rat/env.sh\nIf youre building RAT, please ignore.\nOtherwise, ensure RAT is mounted to /rat\n"
 fi

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+SL_PYTHON27=/opt/rh/python27/enable
+if [ -f "$SL_PYTHON27" ]; then
+   source $SL_PYTHON27
+fi
+
 source /home/software/root/bin/thisroot.sh
 source /home/software/geant4.10.00.p04/bin/geant4.sh
 
-export RAT_SCONS=/home/software/scons-3.1.2
+# export RAT_SCONS=/home/software/scons-3.1.2
+
 # export TF_DIR=/usr/local
 # export CPPFLOW_DIR=/home/software/cppflow
 # export LIBRARY_PATH=$LIBRARY_PATH:$TF_DIR/lib
@@ -11,8 +17,9 @@ export RAT_SCONS=/home/software/scons-3.1.2
 # export LIBRARY_PATH=$LIBRARY_PATH:$CPPFLOW_DIR/lib
 # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CPPFLOW_DIR/lib
 
-if [ -f /rat/env.sh ]; then
-    source /rat/env.sh
+RAT_ENV=/rat/env.sh
+if [ -f "$RAT_ENV" ]; then
+    source $RAT_ENV
 else
     printf "\nCould not find /rat/env.sh\nIf youre building RAT, please ignore.\nOtherwise, ensure RAT is mounted to /rat\n"
 fi


### PR DESCRIPTION
This PR fixes and updates the RAT environment script, which was forgotten about in PR #23. Now, `docker-entrypoint.sh` sources `setup-env.sh`.